### PR TITLE
[사전 미션 - 워밍업] - 카멜(진나영) 미션 제출합니다.

### DIFF
--- a/a11y/index.html
+++ b/a11y/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
 
 <head>
   <meta charset="UTF-8" />

--- a/a11y/package.json
+++ b/a11y/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "my-react-app",
+  "name": "camel-paced-enhance-usability",
   "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/a11y/src/App.tsx
+++ b/a11y/src/App.tsx
@@ -6,11 +6,11 @@ import FlightBooking from "./components/FlightBooking";
 function App() {
   return (
     <div className="app">
-      <div className="app-main">
-        <div className="flight-booking-container">
+      <main className="app-main">
+        <section className="flight-booking-container">
           <FlightBooking />
-        </div>
-      </div>
+        </section>
+      </main>
     </div>
   );
 }

--- a/a11y/src/components/FlightBooking.css
+++ b/a11y/src/components/FlightBooking.css
@@ -34,7 +34,7 @@
   width: 30px;
   height: 30px;
   border-radius: 16px;
-  border: 1px solid #C0C0C0;
+  border: 1px solid #c0c0c0;
   background-color: #fff;
   cursor: pointer;
   display: flex;
@@ -60,4 +60,16 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/a11y/src/components/FlightBooking.css
+++ b/a11y/src/components/FlightBooking.css
@@ -40,6 +40,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  &.disabled {
+    cursor: not-allowed;
+    color: #818181ff;
+    background-color: #e1e1e1ff;
+  }
 }
 
 .counter span {

--- a/a11y/src/components/FlightBooking.tsx
+++ b/a11y/src/components/FlightBooking.tsx
@@ -19,13 +19,23 @@ const FlightBooking = () => {
     <div className="flight-booking">
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className="passenger-count">
-        <span className="body-text">성인</span>
+        <label className="body-text" htmlFor="adult-count">
+          성인
+        </label>
         <div className="counter">
-          <button className="button-text" onClick={decrementCount}>
+          <button
+            className="button-text"
+            aria-label="성인 승객 감소"
+            onClick={decrementCount}
+          >
             -
           </button>
-          <span>{adultCount}</span>
-          <button className="button-text" onClick={incrementCount}>
+          <span aria-live="polite">{adultCount}</span>
+          <button
+            className="button-text"
+            aria-label="성인 승객 증가"
+            onClick={incrementCount}
+          >
             +
           </button>
         </div>

--- a/a11y/src/components/FlightBooking.tsx
+++ b/a11y/src/components/FlightBooking.tsx
@@ -2,16 +2,30 @@ import { useState } from "react";
 
 import "./FlightBooking.css";
 
+const MIN_PASSENGERS = 1;
 const MAX_PASSENGERS = 3;
 
 const FlightBooking = () => {
   const [adultCount, setAdultCount] = useState(1);
+  const [statusMessage, setStatusMessage] = useState("");
 
   const incrementCount = () => {
+    if (adultCount === MAX_PASSENGERS) {
+      setStatusMessage(
+        `최대 승객 수에 도달했습니다. 현재 승객 수는 ${adultCount}명 입니다.`
+      );
+      return;
+    }
     setAdultCount((prev) => Math.min(MAX_PASSENGERS, prev + 1));
   };
 
   const decrementCount = () => {
+    if (adultCount === MIN_PASSENGERS) {
+      setStatusMessage(
+        `최소 승객 수에 도달했습니다. 현재 승객 수는 ${adultCount}명 입니다.`
+      );
+      return;
+    }
     setAdultCount((prev) => Math.max(1, prev - 1));
   };
 
@@ -38,6 +52,11 @@ const FlightBooking = () => {
           >
             +
           </button>
+          {statusMessage && (
+            <div className="visually-hidden" role="alert">
+              {statusMessage}
+            </div>
+          )}
         </div>
       </div>
       <button className="search-button">항공편 검색</button>

--- a/a11y/src/components/FlightBooking.tsx
+++ b/a11y/src/components/FlightBooking.tsx
@@ -38,7 +38,9 @@ const FlightBooking = () => {
         </label>
         <div className="counter">
           <button
-            className="button-text"
+            className={`button-text ${
+              adultCount === MIN_PASSENGERS ? "disabled" : ""
+            }`}
             aria-label="성인 승객 감소"
             onClick={decrementCount}
           >
@@ -46,7 +48,9 @@ const FlightBooking = () => {
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button
-            className="button-text"
+            className={`button-text ${
+              adultCount === MAX_PASSENGERS ? "disabled" : ""
+            }`}
             aria-label="성인 승객 증가"
             onClick={incrementCount}
           >


### PR DESCRIPTION
준, 안녕하세요! 카멜입니다. 좋은 주말 보내셨나요?😃😄

그냥 하면 좋다고만 알고 있었던 aria, role 등의 속성을 직접 스크린 리더로 체험해보면서 개선하니 중요성을 잘 느낄 수 있었어요!
좋은 학습이 되었습니다 ㅎㅎ

---

개선 사항

- 시맨틱 태그를 개선하였습니다. [7a11de7](https://github.com/woowacourse/self-paced-enhance-usability/pull/62/commits/7a11de784551e0f523e6925fa96c6fd040927afb)
- index.html 의 언어를 한국어로 설정하였습니다. [e21d33f](https://github.com/woowacourse/self-paced-enhance-usability/pull/62/commits/e21d33fe5f4b6de993d2032b4028132c38e173c6)
- 스크린 리더로 승객 수를 늘리거나 줄일 때 반영된 승객 수를 들을 수 있게 하였습니다. [5713801](https://github.com/woowacourse/self-paced-enhance-usability/pull/62/commits/57138017cc41fdefca4068fd5a39752e26f63244)
- 최소/최대 승객 수에 도달 시 안내 메세지를 읽어주도록 하였습니다. [5713801](https://github.com/woowacourse/self-paced-enhance-usability/pull/62/commits/57138017cc41fdefca4068fd5a39752e26f63244)
    - disabled 스타일을 적용하여 안내 음성 메세지 뿐 아니라 일반 사용자들도 '감소/증가 버튼 비활성화' 상태를 직관적으로 알 수 있도록 하였습니다. [fa7b7ed](https://github.com/woowacourse/self-paced-enhance-usability/pull/62/commits/fa7b7ed41bb8713959fd8b9bf2dfabf638d3bdee)


---

- [x] 스크린 리더로 성인 승객 수를 늘리거나 줄일 수 있어야 한다.
    - [x] 인원 수는 최소 1명, 최대 3명까지만 가능하게 구현한다.
- [x] 승객 수를 늘리는 경우 실제 스크린 리더는 아래와 같이 읽을 수 있어야 한다.

```

const result = ""

항공권 예매
성인
성인 승객 감소, 버튼
1
성인 승객 증가, 버튼
(선택)
성인 승객 증가
2
(선택)
성인 승객 증가
3
(선택)
최대 승객 수에 도달했습니다.

```
---

감사합니다!
